### PR TITLE
Allow to build the project on native Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ WORKDIR /dcdecomp
 COPY . .
 
 # Build the project
-RUN 
+# RUN 
 
 # Output the build
 CMD make setup \

--- a/README.md
+++ b/README.md
@@ -4,18 +4,27 @@ DCDecomp is a work-in-progress decompilation project for Dark Cloud for the Play
 
 This project is targeting the NTSC 1.02 version of the game. Other versions may be considered in the future, though they aren't currently planned.
 
-This aims to be a matching decompilation project. Currently an elf is produced with text and data sections identical to the original. The compiler used by Level 5 (and by extension this project) is ``MWCC/MWLD 2.3.1.01``. In future strategies of matching the symbol/strings tables may be explored, though this isn't a current priority.
+This aims to be a matching decompilation project. Currently an elf is produced with text and data sections identical to the original. The compiler used by Level 5 (and by extension this project) is `MWCC/MWLD 2.3.1.01`. In future strategies of matching the symbol/strings tables may be explored, though this isn't a current priority.
 
 # Building
 
 ## Windows
+
 1. Install [Docker for Windows](https://docs.docker.com/desktop/install/windows-install/)
 2. Install [git](https://git-scm.com/download/win)
-3. Clone the project with ``git clone --recurse-submodules https://github.com/Adubbz/DCDecomp.git``
-4. Place the NTSC 1.02 ISO with the name ``Dark Cloud (USA).iso`` inside the ``rom`` folder at the root of the project.
-5. Run ``scripts\build.bat`` within the project directory.
+3. Clone the project with `git clone --recurse-submodules https://github.com/Adubbz/DCDecomp.git`
+4. Place the NTSC 1.02 ISO with the name `Dark Cloud (USA).iso` inside the `rom` folder at the root of the project.
+5. Run `scripts\build.bat` within the project directory.
+
+## Linux (works on immutable distros with SELinux enabled)
+
+1. Install [Docker for Linux](https://docs.docker.com/desktop/setup/install/linux/)
+2. Clone the project with `git clone --recurse-submodules https://github.com/Adubbz/DCDecomp.git`
+3. Place the NTSC 1.02 ISO with the name `Dark Cloud (USA).iso` inside the `rom` folder at the root of the project.
+4. Run `scripts\build.sh` within the project directory.
 
 # Development
 
 ## Windows
-It is strongly advised that when developing with WSL 2 that you **DO NOT** store the project in a subdirectory of ``/mnt``. This is severely detrimental to filesystem performance and by extension compilation performance.
+
+It is strongly advised that when developing with WSL 2 that you **DO NOT** store the project in a subdirectory of `/mnt`. This is severely detrimental to filesystem performance and by extension compilation performance.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Figure out where this script lives, then go up one directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Check for Docker (or Podman)
+if ! command -v docker &>/dev/null && ! command -v podman &>/dev/null; then
+  echo "Docker or Podman not found! Please install one from:"
+  echo "  https://docs.docker.com/desktop/install"
+  exit 1
+fi
+
+# Build with Podman if available, otherwise Docker
+if command -v podman &>/dev/null; then
+  BUILDER=podman
+else
+  BUILDER=docker
+fi
+
+# Build the image
+"$BUILDER" build -t dcdecomp_build --target build .
+
+# Run the container, mounting the local build/ directory into /output
+"$BUILDER" run --rm \
+  -v "$(pwd)/build:/output:Z" \
+  dcdecomp_build


### PR DESCRIPTION
This is just a few small changes to allow to build the project on Linux, especially one that has SELinux and Podman which is very common on modern immutable distros. Without these changes I wouldn't be able to do much.

P.S.

I love this game and I hope that by making it a bit more accessible to decompile we will attract some more people too.

Thank you for opening the way and starting this decompilation project, it will be my very first 🙂

If you want to contact me you can find me on Discord with the username "Plarpoon"