### PR TITLE
Supply the eighteen unmatched editloop3 functions from assembly again

### DIFF
--- a/include/include_asm.h
+++ b/include/include_asm.h
@@ -39,6 +39,17 @@
  * branch offsets, differing only in register fields. A function that drifts
  * further, or one that differs without the declaration, is a failure, and any
  * difference in data is a failure whether declared or not.
+ *
+ * `NON_MATCHING` is neither: it keeps a decompiled function that does not
+ * reproduce retail's code yet, without letting it into the build. The build
+ * never defines it, so the `#else` branch's `INCLUDE_ASM` is what links and the
+ * image is unaffected. A function whose compiled length differs from retail's
+ * cannot simply be left in the build -- mwcc emits a unit's functions as one
+ * contiguous .text, so it would move every function and every section after it.
+ * The guarded code is kept so the draft can be worked on until it matches.
+ * Note that mwccgap cannot yet compile a unit with the macro defined: it pairs
+ * each `INCLUDE_ASM` it finds in the source text with a gap in the compiled
+ * object, and there is no gap when the C++ was compiled instead.
  */
 
 #define INCLUDE_ASM(FOLDER, NAME)

--- a/src/editloop3.cpp
+++ b/src/editloop3.cpp
@@ -1591,6 +1591,8 @@ int _GET_CHARA_ROT(RS_STACKDATA *stack, int argument_count) {
     return 1;
 }
 
+int _TURN_CHARA(RS_STACKDATA *stack, int argument_count);
+#ifdef NON_MATCHING
 int _TURN_CHARA(RS_STACKDATA *stack, int) {
     sceVu0FVECTOR position;
     GetPosition(stack, position);
@@ -1598,6 +1600,9 @@ int _TURN_CHARA(RS_STACKDATA *stack, int) {
     turn_chara(EdEventInfo.main_character, position, GetStackFloat(stack));
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _TURN_CHARA__FP12RS_STACKDATAi);
+#endif
 
 int _GET_NPC_TALK_POS(RS_STACKDATA *stack, int argument_count) {
     int position[2];
@@ -1808,6 +1813,7 @@ int _TURN_NPC(RS_STACKDATA *stack, int argument_count) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _NPC_DRAW(RS_STACKDATA *stack, int argument_count) {
     int draw = GetStackInt(stack++);
     for (int i = 0; i < argument_count - 1; i++) {
@@ -1821,7 +1827,11 @@ int _NPC_DRAW(RS_STACKDATA *stack, int argument_count) {
     }
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _NPC_DRAW__FP12RS_STACKDATAi);
+#endif
 
+#ifdef NON_MATCHING
 int _NPC_DRAW_SHADOW(RS_STACKDATA *stack, int argument_count) {
     int draw = GetStackInt(stack++);
     for (int i = 0; i < argument_count - 1; i++) {
@@ -1835,7 +1845,11 @@ int _NPC_DRAW_SHADOW(RS_STACKDATA *stack, int argument_count) {
     }
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _NPC_DRAW_SHADOW__FP12RS_STACKDATAi);
+#endif
 
+#ifdef NON_MATCHING
 int _SET_NPC_FOOT_SOUND(RS_STACKDATA *stack, int argument_count) {
     int mode = GetStackInt(stack++);
     for (int i = 0; i < argument_count - 1; i++) {
@@ -1852,6 +1866,9 @@ int _SET_NPC_FOOT_SOUND(RS_STACKDATA *stack, int argument_count) {
     }
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _SET_NPC_FOOT_SOUND__FP12RS_STACKDATAi);
+#endif
 
 int _SET_NPC_FLOOR_ID(RS_STACKDATA *stack, int) {
     RS_STACKDATA *argument = (0, stack + 1);
@@ -2093,6 +2110,7 @@ int _MES_NEXTPAGE(RS_STACKDATA *stack, int) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _SET_MES_AUTOSET(RS_STACKDATA *stack, int argument_count) {
     ClsMes *message = GetMes(GetStackInt(stack++));
     if (message == NULL)
@@ -2124,6 +2142,9 @@ int _SET_MES_AUTOSET(RS_STACKDATA *stack, int argument_count) {
     }
     return 0;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _SET_MES_AUTOSET__FP12RS_STACKDATAi);
+#endif
 
 int _SET_MES_SHIPPO(RS_STACKDATA *stack, int argument_count) {
     ClsMes *message = GetMes(GetStackInt(stack++));
@@ -2393,6 +2414,7 @@ int _HOBJ_ITEM(RS_STACKDATA *stack, int) {
     return SetObjHandle(handle_index, frame) != 0 ? 1 : 0;
 }
 
+#ifdef NON_MATCHING
 int _OBJ_DRAW(RS_STACKDATA *stack, int argument_count) {
     int draw = GetStackInt(stack++);
     for (int i = 0; i < argument_count - 1; i++) {
@@ -2402,6 +2424,9 @@ int _OBJ_DRAW(RS_STACKDATA *stack, int argument_count) {
     }
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _OBJ_DRAW__FP12RS_STACKDATAi);
+#endif
 
 int _SET_OBJ_POS(RS_STACKDATA *stack, int) {
     sceVu0FVECTOR position;
@@ -2529,6 +2554,7 @@ int _GET_TALKNPC_ID(RS_STACKDATA *stack, int argument_count) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _GET_TALKNPC_STATUS(RS_STACKDATA *stack, int) {
     int index = EdEventInfo.talk_npc_id;
     int status = 0;
@@ -2539,6 +2565,9 @@ int _GET_TALKNPC_STATUS(RS_STACKDATA *stack, int) {
     SetStack(stack, status);
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _GET_TALKNPC_STATUS__FP12RS_STACKDATAi);
+#endif
 
 int _SET_TALK_CAMERA(RS_STACKDATA *stack, int) {
     static sceVu0FVECTOR vv[3] = {
@@ -2604,6 +2633,7 @@ int _SET_TALK_SELECT_MES(RS_STACKDATA *stack, int) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _EVERY_TALK_EVENT(RS_STACKDATA *stack, int argument_count) {
     int villager_id = GetStackInt(stack++);
     if (villager_id < 0 || villager_id >= 16)
@@ -2618,6 +2648,9 @@ int _EVERY_TALK_EVENT(RS_STACKDATA *stack, int argument_count) {
     }
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _EVERY_TALK_EVENT__FP12RS_STACKDATAi);
+#endif
 
 CCameraFollow *GetCamera() {
     CCameraFollow *camera = EdEventInfo.camera;
@@ -2971,6 +3004,7 @@ int _DRAW_SHADOW(RS_STACKDATA *stack, int) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _SET_CLIP_POINT(RS_STACKDATA *stack, int) {
     sceVu0FVECTOR plane;
     RS_STACKDATA *distance_argument = stack + 3;
@@ -2982,6 +3016,9 @@ int _SET_CLIP_POINT(RS_STACKDATA *stack, int) {
     }
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _SET_CLIP_POINT__FP12RS_STACKDATAi);
+#endif
 
 int _DRAW_EDIT_WATER(RS_STACKDATA *stack, int) {
     if (EdEventInfo.edit_ground != NULL)
@@ -3239,6 +3276,7 @@ int _ASQ_INIT(RS_STACKDATA *stack, int) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _ASQ_SYNC_CHARA(RS_STACKDATA *stack, int) {
     int sequence_index = GetStackInt(stack++);
     int character_index = GetStackInt(stack);
@@ -3255,6 +3293,9 @@ int _ASQ_SYNC_CHARA(RS_STACKDATA *stack, int) {
     sequence->SyncChara(character);
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _ASQ_SYNC_CHARA__FP12RS_STACKDATAi);
+#endif
 
 int _ASQ_SET_POS(RS_STACKDATA *stack, int) {
     RS_STACKDATA *arguments = (0, stack + 1);
@@ -3282,6 +3323,7 @@ int _ASQ_MOVE(RS_STACKDATA *stack, int argument_count) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _ASQ_MOVE_STEP(RS_STACKDATA *stack, int) {
     RS_STACKDATA *arguments = (0, stack + 1);
     CActionSeq *sequence = GetActSeq(GetStackInt(stack));
@@ -3292,7 +3334,11 @@ int _ASQ_MOVE_STEP(RS_STACKDATA *stack, int) {
     sequence->MoveSeq(position, GetStackFloat(arguments + 3));
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _ASQ_MOVE_STEP__FP12RS_STACKDATAi);
+#endif
 
+#ifdef NON_MATCHING
 int _ASQ_ROT_REF(RS_STACKDATA *stack, int) {
     RS_STACKDATA *arguments = (0, stack + 1);
     CActionSeq *sequence = GetActSeq(GetStackInt(stack));
@@ -3303,6 +3349,9 @@ int _ASQ_ROT_REF(RS_STACKDATA *stack, int) {
     sequence->RotRefSeq(position, GetStackFloat(arguments + 3));
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _ASQ_ROT_REF__FP12RS_STACKDATAi);
+#endif
 
 int _ASQ_ROT_ANGLE(RS_STACKDATA *stack, int) {
     sceVu0FVECTOR rotation;
@@ -3441,6 +3490,7 @@ int _ASQ_ANIME(RS_STACKDATA *stack, int argument_count) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _ASQ_CHECK(RS_STACKDATA *stack, int) {
     RS_STACKDATA *result = (0, stack + 1);
     CActionSeq *sequence = GetActSeq(GetStackInt(stack));
@@ -3450,6 +3500,9 @@ int _ASQ_CHECK(RS_STACKDATA *stack, int) {
     SetStack(result, (0, ((ended != 0) ^ 1) & 0xFF));
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _ASQ_CHECK__FP12RS_STACKDATAi);
+#endif
 
 int _OBJ_ANIME_INIT(RS_STACKDATA *stack, int argument_count) {
     for (int i = 0; i < argument_count; i++)
@@ -3596,11 +3649,15 @@ int _SGET_DUNGEON_STATUS(RS_STACKDATA *stack, int) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _SGET_PARTY_NUM(RS_STACKDATA *stack, int) {
     CDngStatusData *status = SaveData->GetDngStatus();
     SetStack(stack, status->party_size);
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _SGET_PARTY_NUM__FP12RS_STACKDATAi);
+#endif
 
 int _SSET_PARTY_NUM(RS_STACKDATA *stack, int) {
     CDngStatusData *status = SaveData->GetDngStatus();
@@ -3618,6 +3675,7 @@ int _SSET_REQUEST_EVENT_FLAG(RS_STACKDATA *stack, int) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _SADD_VISIT_MAP(RS_STACKDATA *stack, int argument_count) {
     int map = GetStackInt(stack++) - 1;
     int add = 1;
@@ -3632,6 +3690,9 @@ int _SADD_VISIT_MAP(RS_STACKDATA *stack, int argument_count) {
         SetStack(stack, visits);
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _SADD_VISIT_MAP__FP12RS_STACKDATAi);
+#endif
 
 int _SSKILL_GET(RS_STACKDATA *stack, int) {
     CDngStatusData *status = SaveData->GetDngStatus();
@@ -3676,6 +3737,7 @@ int _SATRA_CHIP_GET(RS_STACKDATA *stack, int) {
     SaveData->AtraChipGet(georama, GetStackInt(next));
 }
 
+#ifdef NON_MATCHING
 int _SGET_REQUEST(RS_STACKDATA *stack, int) {
     RS_STACKDATA *result = (0, stack + 1);
     SV_GEORAMA_DATA *georama = SaveData->GetGrdData(GetStackInt(stack) - 1);
@@ -3698,6 +3760,9 @@ int _SGET_REQUEST(RS_STACKDATA *stack, int) {
         SetStack(result, completed * 100 / total);
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _SGET_REQUEST__FP12RS_STACKDATAi);
+#endif
 
 int _SGET_ATRA_PARTS_NUM(RS_STACKDATA *stack, int) {
     int count = 0;
@@ -4053,6 +4118,7 @@ int _LOAD_FISHING_DATA(RS_STACKDATA *stack, int) {
     return 1;
 }
 
+#ifdef NON_MATCHING
 int _GOTO_FISHING(RS_STACKDATA *, int) {
     CCharacter *character = GetChara(-1);
     if (character == NULL)
@@ -4068,6 +4134,9 @@ int _GOTO_FISHING(RS_STACKDATA *, int) {
     EdEventInfo.return_code = 11;
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", _GOTO_FISHING__FP12RS_STACKDATAi);
+#endif
 
 int _INIT_FISH(RS_STACKDATA *stack, int) {
     CBoxVu0 bounds;
@@ -4098,6 +4167,8 @@ INCLUDE_ASM("asm/nonmatchings/editloop3", EdInitEventParamSimple__Fv);
 INCLUDE_ASM("asm/nonmatchings/editloop3", EdInitEventParam__Fv);
 INCLUDE_ASM("asm/nonmatchings/editloop3", EdEventInit__FiP14CDataAlloc2_1_Pc);
 
+void RunEvent(CRunScript *script, int program, CDataAlloc2<1> *arena);
+#ifdef NON_MATCHING
 void RunEvent(CRunScript *script, int program, CDataAlloc2<1> *arena) {
     int used = arena->used;
     EdEventBuffer.base = arena->base + used * 16;
@@ -4110,6 +4181,9 @@ void RunEvent(CRunScript *script, int program, CDataAlloc2<1> *arena) {
     p_jump_map_no = 0;
     script->run(program);
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/editloop3", RunEvent__FP10CRunScriptiP14CDataAlloc2_1_);
+#endif
 
 void EdRunEvent(int program, CDataAlloc2<1> *arena) {
     RunEvent(&EdEventScript, program, arena);


### PR DESCRIPTION
This restores the linked layout that `9f0f383e` shifted. **It decompiles
nothing new and deletes nothing** — every function it touches keeps its C++ and
is supplied from retail's assembly until that C++ matches.

*Updated after Adubbz's feedback: the eighteen bodies are now guarded with
`NON_MATCHING` rather than removed, so the diff is purely additive.*

## What does not shift

- **No build tooling changes.** `CMakeLists.txt`, `SCUS_971.11.lcf`,
  `config/`, `scripts/` and `tools/` are all untouched.
- **Purely additive**: 85 insertions, **0 deletions**, across
  `src/editloop3.cpp` and `include/include_asm.h`.
- **Nothing regresses on any of the three images.**
- No new symbols, no new sections, no data migration, no config fixups.

## The problem

mwcc emits a translation unit's functions as one contiguous `.text`, so a
function whose compiled length differs from retail's moves every function and
every section after it.

`9f0f383e` defines eighteen `editloop3` functions in C++ that do not reproduce
retail's code yet — objdiff scores them between 83.8% and 97.8% — and twelve
compile to a different length:

| function | retail | built |
|---|---|---|
| `_NPC_DRAW`, `_NPC_DRAW_SHADOW` | `0xCC` | `0xD8` |
| `_SET_NPC_FOOT_SOUND` | `0xE8` | `0xF4` |
| `_EVERY_TALK_EVENT` | `0xC4` | `0xD0` |
| `RunEvent` | `0xCC` | `0xD0` |
| `_ASQ_SYNC_CHARA` | `0xB8` | `0xBC` |
| `_SADD_VISIT_MAP` | `0xC4` | `0xC8` |
| `_SET_CLIP_POINT` | `0x8C` | `0x90` |
| `_TURN_CHARA` | `0x5C` | `0x58` |
| `_ASQ_MOVE_STEP`, `_ASQ_ROT_REF` | `0x90` | `0x8C` |
| `_GOTO_FISHING` | `0xC8` | `0xB4` |

`editloop3.cpp.o` ends `0x20` past retail's. The first symbol to move is
`LoadScript__Fv__2` in `edit_in.cpp.o`, and every object after it follows —
which is why the damage reaches TITLE.BIN and DUN.BIN as well as main.

Worth separating out, because the two measures disagree: **on objdiff,
`9f0f383e` is a clear gain — 276 functions reach 100% that did not before, and
only one regresses.** The editloop3 work itself is right. It is only the linked
placement that breaks.

## The change

Each of the eighteen becomes:

```c
#ifdef NON_MATCHING
int _NPC_DRAW(RS_STACKDATA *stack, int argument_count) {
    ...unchanged...
}
#else
INCLUDE_ASM("asm/nonmatchings/editloop3", _NPC_DRAW__FP12RS_STACKDATAi);
#endif
```

The build never defines the macro, so retail's instructions link and the image
lines up; the C++ stays in place to be worked on. `include/include_asm.h`
documents the marker beside `INCLUDE_ASM` and `FUZZY_MATCH`.

The six that happen to be retail's length (`_GET_TALKNPC_STATUS`,
`_SGET_PARTY_NUM`, `_ASQ_CHECK`, `_OBJ_DRAW`, `_SGET_REQUEST`,
`_SET_MES_AUTOSET`) are guarded too: I tried declaring them `FUZZY_MATCH`, and
`verify.py` rejects it, because they differ by more than the register
allocation that declaration permits.

`_TURN_CHARA` and `RunEvent` are called from this unit's own C++, so each gets
a prototype above its guard, in the style `turn_chara` already uses.

**One caveat on the guard.** `mwccgap` cannot currently compile a unit with
`NON_MATCHING` defined — it pairs each `INCLUDE_ASM` it finds in the source
text with a gap in the compiled object, and there is no gap when the C++ was
compiled instead, so it stops with `RunEvent__... not found in
src/editloop3.cpp`. The normal build is unaffected. So today the guard
preserves the drafts but does not yet give you a one-flag way to build them;
teaching mwccgap to skip a marker in the inactive branch would, if you want
that.

## Result

Measured in a fresh clone — `git clone --no-local`, submodules initialised, the
disc hash checked — with this repo's own `scripts/build/cmake.sh` and
`scripts/build/verify.py`.

| | `9f0f383e` | with this change |
|---|---|---|
| SCUS_971.11 byte-perfect | 458 | **813** |
| SCUS_971.11 data bytes differing | 418734 | **47660** |
| TITLE.BIN | 41 perfect, 129 unmatched | 42 perfect, 128 unmatched |
| DUN.BIN | 2 perfect, 59 unmatched | 2 perfect, 58 unmatched |
| whole image, perfect by byte | 501 (6.61%) | **857 (13.37%)** |

`.text` and `.data` in SCUS_971.11 are byte-identical to retail again, and
`editloop3.cpp.o`'s own `.fishinglineorigin` lands exactly at the `0x269C40`
the linker script documents for it.

## What this does not fix

The residual 47660 bytes are `.rodata`, `.vudata` and bss, all carried `0x80`
along by six `.data` constants `editloop3.cpp.o` emits that no linker script
line places — `@1251`, `@1364`, `vv$1647`, `@1742`, `@1743`, `@1982`. They
collect at the end of `.data`. Only `vv$1647` has a counterpart in the residual
dump, at `0x269BC0`; the others are compiler-numbered with no direct retail
name, so placing them looked like a decision about your `rodata_exports` /
`sections` machinery rather than something to guess at.

**I am working on that part now** and will follow up. If you already know how
you want those six placed, saying so will save me guessing at it.

TITLE.BIN and DUN.BIN are still short of where they were at `6e29aac0` (170 and
55 perfect) after this change, and I have not diagnosed that separately.
`CheckDmg__12CMonstorUnitFv` also slipped from objdiff 100% to 99.69% in
`9f0f383e`.

## Reproducing

```
git checkout <this branch>
git submodule update --init --recursive
cp "Dark Cloud (USA).iso" rom/ && (cd rom && sha256sum -c checksum.sha256)
scripts/build/cmake.sh elf objdiff
python scripts/build/verify.py -c
```

Check out `9f0f383e` and repeat for the base.

## Things you may want changed

- **The macro name.** I used `NON_MATCHING` as the conventional one; the repo
  had none. Easy to rename.
- **The six right-length functions.** If you would rather they stayed live as
  C++ despite `verify.py` rejecting `FUZZY_MATCH`, that is easy to split out.
- **The two prototypes**, if you would prefer them in a header instead.
- A fresh split still leaves the `editloop3` reference files that `9f0f383e`
  matched but never moved from `asm/nonmatchings/` to `asm/matchings/` — 322 on
  the base, 304 with this change. I left that dirt alone rather than fold it in;
  happy to send it as its own PR.
